### PR TITLE
Fix: Typo in main execution

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,41 +1,41 @@
-import openai
 import warnings
 
+import openai
 from rich import print
 from rich.markdown import Markdown
 from termcolor import colored
 
 warnings.filterwarnings("ignore")
 
-def get_openai_response(messages):
 
+def get_openai_response(messages):
     response = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=messages,
         temperature=0.7,
     )
 
-    return response.choices[0]['message']
+    return response.choices[0]["message"]
+
 
 def main():
-
     messages = []
 
     while True:
-
         prompt = input(colored("You: ", "green"))
-        
+
         if prompt.lower() in ["exit", "quit"]:
             break
 
         messages.append({"role": "user", "content": prompt})
-        
+
         response = get_openai_response(messages)
         messages.append(dict(response))
 
-        print('\n')
-        print(Markdown(response['content']))
-        print('\n')
+        print("\n")
+        print(Markdown(response["content"]))
+        print("\n")
+
 
 if __name__ == "__main__":
-    main()it
+    main()


### PR DESCRIPTION
There was a typo in `if __name__ == "__main__":` section.